### PR TITLE
Add budget manual testing instructions to DG and bug fixes

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -641,6 +641,67 @@ Correct format: `search KEYWORD`
 6. Test case: `search loan` (search by category).
 - Expected: Displays all loans since they match the "loan" category.
 
+### Setting budget
+
+Correct format: `budget AMOUNT` or `budget c/CATEGORY a/AMOUNT`
+
+Eg: `budget 1000` (global budget) or `budget c/food a/200` (category budget)
+
+1. Test case: Set global budget.
+
+    Eg: `budget 1000`
+- Expected: `Global budget set to $1000.00`
+
+2. Test case: Set category budget.
+
+    Eg: `budget c/food a/200`
+- Expected: `Budget for food set to $200.00`
+
+3. Test case: Negative budget amount.
+
+    Eg: `budget -100`
+- Expected: `Budget must be a positive number!`
+
+4. Test case: NaN or Infinity budget amount.
+
+    Eg: `budget NaN`
+- Expected: `Budget must be a valid number!`
+
+5. Test case: Category budget for loan category.
+
+    Eg: `budget c/loan a/100`
+- Expected: `Loans cannot have a budget. Only expenses (food, groceries, transport, others) can have budgets.`
+
+6. Test case: List budgets.
+
+    Eg: `list budgets`
+- Expected: Displays global budget and all category budgets with their remaining amounts.
+
+### Checking remaining budget
+
+After adding expenses, the application tracks remaining budget automatically.
+
+1. Test case: Check remaining budget after adding expenses.
+
+    Steps:
+    - Set budget: `budget 1000`
+    - Add expense: `add c/food n/Lunch a/10`
+- Expected: `Remaining Budget: $990.00`
+
+2. Test case: Check remaining budget after editing expense.
+
+    Steps:
+    - Add expense: `add c/food n/Lunch a/10`
+    - Edit expense: `edit 1 a/20`
+- Expected: Remaining budget decreases by additional $10
+
+3. Test case: Check category budget remaining.
+
+    Steps:
+    - Set category budget: `budget c/food a/200`
+    - Add food expense: `add c/food n/Lunch a/50`
+- Expected: Food category remaining budget shows $150.00
+
 ### Saving data
 **WARNING:** Save a copy of expenses.txt elsewhere first before attempting any changes to expenses.txt.
 

--- a/src/main/java/seedu/duke/EditCommand.java
+++ b/src/main/java/seedu/duke/EditCommand.java
@@ -29,6 +29,16 @@ public class EditCommand extends Command {
             loanManager.editLoan(index, name, value, date);
             ui.showMessage("Loan at index " + (index + 1) + " updated successfully!");
         } else {
+            // Check if category is valid, warn if it will be converted to Others
+            if (category != null) {
+                String normalizedCategory = category.toLowerCase();
+                if (!normalizedCategory.equals("food") && !normalizedCategory.equals("transport")
+                        && !normalizedCategory.equals("groceries") && !normalizedCategory.equals("others")) {
+                    ui.showMessage("Warning: Category '" + category + "' is not recognized. "
+                            + "It has been converted to 'Others'.");
+                }
+            }
+
             ExpenseManager expenseManager = managers.getExpenseManager();
             expenseManager.editExpense(index, category, name, value, date);
             ui.showMessage("Expense at index " + (index + 1) + " updated successfully!");

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -44,6 +44,9 @@ public class Parser {
 
                 // Default to global budget command
                 double budgetAmount = Double.parseDouble(partsBySpace[1]);
+                if (Double.isNaN(budgetAmount) || Double.isInfinite(budgetAmount)) {
+                    throw new ExpensiveLehException("Budget must be a valid number!");
+                }
                 if (budgetAmount <= 0) {
                     throw new ExpensiveLehException("Budget must be a positive number!");
                 }
@@ -241,6 +244,9 @@ public class Parser {
                 throw new ExpensiveLehException(
                         "AMOUNT is required. Usage: add c/CATEGORY n/NAME a/AMOUNT [d/DD-MM-YYYY]");
             }
+            if (Double.isNaN(amount) || Double.isInfinite(amount)) {
+                throw new ExpensiveLehException("Amount must be a valid number!");
+            }
             if (amount <= 0) {
                 throw new ExpensiveLehException("Amount must be positive!");
             }
@@ -389,8 +395,13 @@ public class Parser {
                         "Please specify at least one field to edit: c/CATEGORY, n/NAME, a/AMOUNT, or d/DD-MM-YYYY");
             }
 
-            if (amount != null && amount <= 0) {
-                throw new ExpensiveLehException("Amount must be positive.");
+            if (amount != null) {
+                if (Double.isNaN(amount) || Double.isInfinite(amount)) {
+                    throw new ExpensiveLehException("Amount must be a valid number.");
+                }
+                if (amount <= 0) {
+                    throw new ExpensiveLehException("Amount must be positive.");
+                }
             }
 
             // Pass flag to EditCommand
@@ -437,6 +448,9 @@ public class Parser {
             if (amount == null) {
                 throw new ExpensiveLehException(
                         "Amount is required. Usage: budget c/CATEGORY a/AMOUNT");
+            }
+            if (Double.isNaN(amount) || Double.isInfinite(amount)) {
+                throw new ExpensiveLehException("Budget amount must be a valid number.");
             }
             if (amount <= 0) {
                 throw new ExpensiveLehException("Budget amount must be positive.");

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -215,6 +215,9 @@ public class Parser {
                     date = LocalDate.parse(part.substring(2),
                             java.time.format.DateTimeFormatter.ofPattern("dd-MM-yyyy"));
                     hasDate = true;
+                } else if (part.startsWith("/") && part.length() > 1) {
+                    throw new ExpensiveLehException("Invalid format. Please use n/ for name, a/ for amount, "
+                            + "c/ for category, or d/ for date. Usage: add c/CATEGORY n/NAME a/AMOUNT [d/DD-MM-YYYY]");
                 }
             }
 
@@ -377,6 +380,10 @@ public class Parser {
                     date = LocalDate.parse(part.substring(2),
                             java.time.format.DateTimeFormatter.ofPattern("dd-MM-yyyy"));
                     hasDate = true;
+                } else if (part.startsWith("/") && part.length() > 1) {
+                    throw new ExpensiveLehException("Invalid format. Please use n/ for name, a/ for amount, "
+                            + "c/ for category, or d/ for date. Usage: edit [loan/expense] INDEX "
+                            + "[c/CATEGORY] [n/NAME] [a/AMOUNT] [d/DD-MM-YYYY]");
                 }
             }
 


### PR DESCRIPTION
- Reject NaN and Infinity values in amount validation (Resolves #113, #137, #145)
- Reject invalid format without n/ and a/ prefixes in edit command (Resolves #146)
- Notify user when invalid category is converted to Others in edit command (Resolves #140)
- Add budget manual testing instructions to DeveloperGuide