### PR TITLE
Fix #128, #130, #110: Budget duplicate fields and exit command docs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -500,7 +500,7 @@ To search for expenses and loans, use 'search KEYWORD'. Eg: search chicken
 To rank expenses by amount, use 'rank expenses'
 To rank loans by amount, use 'rank loans'
 To view all commands, use 'help'
-To exit the program, use 'exit'
+To exit the program, use 'exit', 'bye' or 'quit'
 ________________________________________________________________
 ```
 
@@ -510,7 +510,7 @@ Loans, expenses, bookmarks and budgets are automatically saved in the disk. Ther
 ### Exit
 Exits the program.
 
-Format: `exit`
+Format: `exit` or `bye` or `quit`
 
 Output:
 ```
@@ -558,6 +558,6 @@ ________________________________________________________________
 | Rank expenses            | `rank expenses`                                              | `rank expenses`                                 |
 | Rank loans               | `rank loans`                                                 | `rank loans`                                    |
 | Help                     | `help`                                                       | `help`                                          |
-| Exit                     | `exit`                                                       | `exit`                                          |
+| Exit                     | `exit` or `bye` or `quit`                                   | `exit`                                          |
 
 ```

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -434,12 +434,24 @@ public class Parser {
 
         try {
             String[] parts = line.split("\\s+");
+            boolean hasCategory = false;
+            boolean hasAmount = false;
             for (int i = 1; i < parts.length; i++) {
                 String part = parts[i];
                 if (part.startsWith("c/")) {
+                    if (hasCategory) {
+                        throw new ExpensiveLehException("Duplicate category flag 'c/' found. "
+                                + "Usage: budget c/CATEGORY a/AMOUNT");
+                    }
                     category = part.substring(2);
+                    hasCategory = true;
                 } else if (part.startsWith("a/")) {
+                    if (hasAmount) {
+                        throw new ExpensiveLehException("Duplicate amount flag 'a/' found. "
+                                + "Usage: budget c/CATEGORY a/AMOUNT");
+                    }
                     amount = Double.parseDouble(part.substring(2));
+                    hasAmount = true;
                 }
             }
 


### PR DESCRIPTION
Fixes duplicate field validation in budget category commands and documents alternative exit commands in UG.                                                                                                                                              

Resolves #128
Resolves #130 
Resolves #110 