### PR TITLE
Fix PE-D issues #141 and #132

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -210,7 +210,9 @@ The add expense feature is implemented through the `AddCommand` class and `Expen
     - Ensures amount is non-negative, finite, and not NaN
     - Uses assertions to verify the expense is added to the list
 
-5. **Feedback**: The UI displays a success message with the expense details and remaining budget.
+5. **Budget Violation Check**: After adding the expense, the system checks if a category budget was set and if the expense exceeds it. Similarly, it checks if the global budget is exceeded. If either condition is met, a warning message is appended to the output showing the overspent amount.
+
+6. **Feedback**: The UI displays a success message with the expense details and remaining budget, along with any budget violation warnings.
 
 Example:
 
@@ -316,7 +318,9 @@ edit 2 a/6.00
 
 **Step 3.** The expense is replaced in the list using `expenses.set(index, newExpense)`.
 
-**Step 4.** The UI confirms the update.
+**Step 4.** The system checks if editing the expense would exceed the category budget or global budget. If so, a warning message is appended.
+
+**Step 5.** The UI confirms the update and displays any budget violation warnings.
 
 ![Edit Expense Sequence Diagram](Diagrams/EditExpenseSequenceDiagram.png)
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -440,7 +440,6 @@ The sequence diagram below illustrates the interactions within the system when a
 
 **Alternative 1 (current choice):** Store global budget as `double` and category budgets as `HashMap<String, Double>`.
 - *Pros*: Simple, straightforward implementation, easy to query
-- *Cons*: No data persistence (budgets are not saved to files)
 
 **Alternative 2:** Create a `Budget` class with methods for all budget operations.
 - *Pros*: Encapsulates budget logic, easier to extend, allows persistence integration

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,6 +59,7 @@ Format: `add c/CATEGORY n/NAME a/AMOUNT [d/DD-MM-YYYY]`
 * `NAME` can contain multiple words but prevents some special characters.
 * `AMOUNT` must be a positive number less than 1,000,000,000.
 * `DATE` is optional and defaults to today's date if not specified.
+* If adding the expense would exceed a category budget or the global budget, a warning will be displayed indicating the overspent amount.
 
 Example: `add c/Food n/Jollibee a/9.95 d/19-03-2026`
 
@@ -74,6 +75,26 @@ Value    : $9.95
 Date     : 19-03-2026
 ================================================
 Remaining Budget: $990.05
+________________________________________________________________
+```
+
+> **Note:** If adding an expense would exceed a category budget or the global budget, a warning will be displayed indicating the overspent amount.
+
+Example: `add c/Food n/Lunch a/60` (assuming Food budget is set to $50)
+
+Output:
+
+```
+________________________________________________________________
+ExpensiveLeh says -> Expense added successfully!
+================================================
+Category : Food
+Name     : Lunch
+Value    : $60.00
+Date     : 14-04-2026
+================================================
+Remaining Budget: $940.00
+Warning: You have overspent the Food budget by $10.00
 ________________________________________________________________
 ```
 
@@ -210,6 +231,19 @@ ________________________________________________________________
 ExpensiveLeh says -> Expense at index 2 updated successfully!
 ________________________________________________________________
 ```
+
+Example: `edit 1 c/Groceries a/10` (changing Food expense to Groceries with Groceries budget set to $30)
+
+Output:
+
+```
+________________________________________________________________
+ExpensiveLeh says -> Expense at index 1 updated successfully!
+Warning: You have overspent the Groceries budget by $5.00
+________________________________________________________________
+```
+
+> **Note:** If editing an expense would exceed a category budget or the global budget, a warning will be displayed indicating the overspent amount.
 
 ### Editing a loan: `edit`
 Edits an existing loan record in the loans list.

--- a/src/main/java/seedu/duke/AddCommand.java
+++ b/src/main/java/seedu/duke/AddCommand.java
@@ -28,14 +28,27 @@ public class AddCommand extends Command {
     private void addExpense(ExpenseManager expenses, UI ui) throws ExpensiveLehException {
         Expense expense = (Expense) itemToAdd;
         expenses.addExpense(expense);
-        ui.showMessage("Expense added successfully!"
+        double categoryBudget = expenses.getCategoryBudget(expense.getCategory());
+        double remainingCategoryBudget = expenses.getRemainingBudgetForCategory(expense.getCategory());
+        double remainingGlobalBudget = expenses.getRemainingBudget();
+        String message = "Expense added successfully!"
                 + "\n================================================"
                 + "\nCategory : " + expense.getCategory()
                 + "\nName     : " + expense.getDescription()
                 + "\nValue    : $" + String.format("%.2f", expense.getAmount())
                 + "\nDate     : " + expense.getFormattedDate()
                 + "\n================================================"
-                + "\nRemaining Budget: $" + String.format("%.2f", expenses.getRemainingBudget()));
+                + "\nRemaining Budget: $" + String.format("%.2f", remainingGlobalBudget);
+
+        if (categoryBudget > 0 && remainingCategoryBudget < 0) {
+            message += "\nWarning: You have overspent the " + expense.getCategory()
+                    + " budget by $" + String.format("%.2f", Math.abs(remainingCategoryBudget));
+        }
+        if (remainingGlobalBudget < 0) {
+            message += "\nWarning: You have overspent the global budget by $"
+                    + String.format("%.2f", Math.abs(remainingGlobalBudget));
+        }
+        ui.showMessage(message);
     }
 
     private void addLoan(LoanManager loans, UI ui) throws ExpensiveLehException {
@@ -68,13 +81,26 @@ public class AddCommand extends Command {
         }
 
         expenses.addExpense(newExpense);
-        ui.showMessage("Expense added successfully!"
+        double categoryBudget = expenses.getCategoryBudget(newExpense.getCategory());
+        double remainingCategoryBudget = expenses.getRemainingBudgetForCategory(newExpense.getCategory());
+        double remainingGlobalBudget = expenses.getRemainingBudget();
+        String message = "Expense added successfully!"
                 + "\n================================================"
                 + "\nCategory : " + newExpense.getCategory()
                 + "\nName     : " + newExpense.getDescription()
                 + "\nValue    : $" + String.format("%.2f", newExpense.getAmount())
                 + "\nDate     : " + newExpense.getFormattedDate()
                 + "\n================================================"
-                + "\nRemaining Budget: $" + String.format("%.2f", expenses.getRemainingBudget()));
+                + "\nRemaining Budget: $" + String.format("%.2f", remainingGlobalBudget);
+
+        if (categoryBudget > 0 && remainingCategoryBudget < 0) {
+            message += "\nWarning: You have overspent the " + newExpense.getCategory()
+                    + " budget by $" + String.format("%.2f", Math.abs(remainingCategoryBudget));
+        }
+        if (remainingGlobalBudget < 0) {
+            message += "\nWarning: You have overspent the global budget by $"
+                    + String.format("%.2f", Math.abs(remainingGlobalBudget));
+        }
+        ui.showMessage(message);
     }
 }

--- a/src/main/java/seedu/duke/CategoryBudgetCommand.java
+++ b/src/main/java/seedu/duke/CategoryBudgetCommand.java
@@ -25,8 +25,8 @@ public class CategoryBudgetCommand extends Command {
         if (totalCategoryBudgets > currentGlobalBudget) {
             expenseManager.setBudget(totalCategoryBudgets);
             ui.showMessage("Budget of $" + String.format("%.2f", amount) + " set successfully for "
-                    + category + "!");
-            ui.showMessage("Global budget updated to $" + String.format("%.2f", totalCategoryBudgets)
+                    + category + "!"
+                    + "\nGlobal budget updated to $" + String.format("%.2f", totalCategoryBudgets)
                     + " as category budgets exceed previous global budget.");
         } else {
             boolean isNewBudget = expenseManager.getCategoryBudget(category) == amount;

--- a/src/main/java/seedu/duke/EditCommand.java
+++ b/src/main/java/seedu/duke/EditCommand.java
@@ -40,8 +40,28 @@ public class EditCommand extends Command {
             }
 
             ExpenseManager expenseManager = managers.getExpenseManager();
+
+            // Get current expense to determine final category
+            Expense currentExpense = expenseManager.getExpense(index);
+            String finalCategory = category != null ? category : currentExpense.getCategory();
+
             expenseManager.editExpense(index, category, name, value, date);
-            ui.showMessage("Expense at index " + (index + 1) + " updated successfully!");
+
+            // Calculate budget impact after editing
+            double categoryBudget = expenseManager.getCategoryBudget(finalCategory);
+            double remainingCategoryBudget = expenseManager.getRemainingBudgetForCategory(finalCategory);
+            double remainingGlobalBudget = expenseManager.getRemainingBudget();
+            String message = "Expense at index " + (index + 1) + " updated successfully!";
+
+            if (categoryBudget > 0 && remainingCategoryBudget < 0) {
+                message += "\nWarning: You have overspent the " + finalCategory
+                        + " budget by $" + String.format("%.2f", Math.abs(remainingCategoryBudget));
+            }
+            if (remainingGlobalBudget < 0) {
+                message += "\nWarning: You have overspent the global budget by $"
+                        + String.format("%.2f", Math.abs(remainingGlobalBudget));
+            }
+            ui.showMessage(message);
         }
     }
 }


### PR DESCRIPTION
- Add budget violation warnings for add and edit expense commands (Resolves #141)
    - Warnings now appear when adding or editing expenses that exceed category or global budgets
    - Fixed category budget output to display in single block when it exceeds global budget
    - Updated UG with examples showing warning output
    - Updated DG with budget violation check documentation
 - Remove contradictory statement about budget persistence in DG (Resolves #132)